### PR TITLE
Add pause system with consent modal for music/jumpscare preferences

### DIFF
--- a/src/components/JumpScare.js
+++ b/src/components/JumpScare.js
@@ -16,9 +16,9 @@ export default class JumpScare {
     this.flash = scene.add.rectangle(0, 0, W, H, 0xffffff, 1)
       .setOrigin(0)
       .setAlpha(0)
-      .setDepth(9999);
+      .setDepth(400);
 
-    this.vignette = scene.add.graphics().setDepth(9998).setAlpha(0);
+    this.vignette = scene.add.graphics().setDepth(399).setAlpha(0);
     this.#drawVignette(W, H);
 
     this.sfxKeys = ['sfx_js_1', 'sfx_js_2'].filter(k => scene.cache.audio.exists(k));
@@ -52,9 +52,26 @@ export default class JumpScare {
     if (this.timer) { this.timer.remove(false); this.timer = null; }
   }
 
+  stopAllEffects() {
+    // Stop any active tweens on flash/vignette
+    this.scene.tweens.getTweensOf(this.flash).forEach(tween => tween.stop());
+    this.scene.tweens.getTweensOf(this.vignette).forEach(tween => tween.stop());
+    
+    // Reset flash and vignette to default state
+    this.flash.setAlpha(0);
+    this.vignette.setAlpha(0);
+    
+    // Reset camera
+    const cam = this.scene.cameras.main;
+    cam.resetFX();
+  }
+
   trigger({ invert = true } = {}) {
     const cam = this.scene.cameras.main;
     const { shakeDur, shakeMag, zoom, volume, invertMs } = this.opts;
+
+    // Don't trigger if game is paused
+    if (this.scene.isPaused) return;
 
     // Only play sound if music is enabled (not muted)
     const musicEnabled = this.scene.registry.get('musicEnabled');
@@ -63,6 +80,7 @@ export default class JumpScare {
       if (key) this.scene.sound.play(key, { volume });
     }
 
+    // Apply visual effects
     cam.shake(shakeDur, shakeMag);
     cam.zoomTo(zoom, 120, 'Quad.easeOut', true, (_c, _p, done) => {
       if (done) cam.zoomTo(1, 180, 'Quad.easeOut', true);
@@ -93,5 +111,17 @@ export default class JumpScare {
     this.stopAuto();
     this.flash.destroy();
     this.vignette.destroy();
+  }
+
+  pauseAnimations() {
+    // Pause all tweens on flash and vignette
+    this.scene.tweens.getTweensOf(this.flash).forEach(tween => tween.pause());
+    this.scene.tweens.getTweensOf(this.vignette).forEach(tween => tween.pause());
+  }
+
+  resumeAnimations() {
+    // Resume all tweens on flash and vignette
+    this.scene.tweens.getTweensOf(this.flash).forEach(tween => tween.resume());
+    this.scene.tweens.getTweensOf(this.vignette).forEach(tween => tween.resume());
   }
 }

--- a/src/components/Obstacle.js
+++ b/src/components/Obstacle.js
@@ -41,6 +41,9 @@ export default class Obstacle {
       console.log('Obstacle (Zombie Hand) created at:', x, y);
     }
   }  update(moveDistance) {
+    // Don't update when paused
+    if (this.scene.isPaused) return;
+    
     // Move LEFT 
     this.sprite.x -= moveDistance;
     this.sprite.body.updateFromGameObject();

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -61,6 +61,9 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
 
   preUpdate(time, delta) {
     super.preUpdate(time, delta);
+    
+    // Don't update when paused
+    if (this.scene.isPaused) return;
 
     // Clamp fall speed
     if (this.body.velocity.y > Player.MAX_FALL) {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import BootScene from "./scenes/BootScene";
 import AboutScene from './scenes/AboutScene';
 import MenuScene from "./scenes/MenuScene";
 import GameScene from "./scenes/GameScene";
+import PauseScene from "./scenes/PauseScene";
 import GameOverScene from "./scenes/GameOverScene";
 
 const config = {
@@ -13,7 +14,7 @@ const config = {
   width: 1280,
   height: 720,
   backgroundColor: "#000000",
-  scene: [BootScene, AboutScene, MenuScene, GameScene, GameOverScene],
+  scene: [BootScene, AboutScene, MenuScene, GameScene, PauseScene, GameOverScene],
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -27,6 +27,9 @@ class GameScene extends Phaser.Scene {
     // Scoring system
     this.distanceTraveled = 0; // Track total distance in pixels
     this.score = 0; // Simple score based on distance
+    
+    // Pause state (don't pause scene, use flag instead to avoid AudioContext issues)
+    this.isPaused = false;
   }
 
   init(data) {
@@ -141,6 +144,47 @@ class GameScene extends Phaser.Scene {
     this.musicButton = MusicManager.createMusicButton(this, W - 20, 20);
     this.setupJumpControls();
 
+    // --- Settings Button (Pause) ---
+    const settingsButton = this.add.text(W - 90, 32, '⚙️', {
+      fontSize: '28px',
+      fontFamily: 'Arial'
+    })
+      .setOrigin(0.5, 0.5)
+      .setScrollFactor(0)
+      .setInteractive({ useHandCursor: true })
+      .setDepth(100);
+
+    settingsButton.on('pointerover', () => {
+      settingsButton.setScale(1.2);
+    });
+
+    settingsButton.on('pointerout', () => {
+      settingsButton.setScale(1.0);
+    });
+
+    settingsButton.on('pointerdown', () => {
+      this.isPaused = true;
+      this.pauseAnimations();
+      this.scene.launch('PauseScene');
+    });
+
+    // P key to pause/unpause
+    this.input.keyboard.on('keydown-P', () => {
+      if (this.isPaused) {
+        // Unpause
+        this.isPaused = false;
+        this.resumeAnimations();
+        this.scene.stop('PauseScene');
+      } else {
+        // Pause
+        this.isPaused = true;
+        this.pauseAnimations();
+        this.scene.launch('PauseScene');
+      }
+    });
+
+    this.setupJumpControls();
+
     // --- Score Display HUD ---
     this.distanceTraveled = 0; // Initialize here as well
     this.score = 0; // Initialize here as well
@@ -199,8 +243,46 @@ class GameScene extends Phaser.Scene {
     this.input.on('pointerup', release);
   }
 
+  pauseAnimations() {
+    // Disable input
+    this.input.enabled = false;
+    
+    // Pause all sprite animations
+    this.player.anims.pause();
+    this.obstacles.forEach(obs => {
+      if (obs.sprite && obs.sprite.anims) {
+        obs.sprite.anims.pause();
+      }
+    });
+    
+    // Pause jumpscare animations if active
+    if (this.jumpScare) {
+      this.jumpScare.pauseAnimations();
+    }
+  }
+
+  resumeAnimations() {
+    // Enable input
+    this.input.enabled = true;
+    
+    // Resume all sprite animations
+    this.player.anims.resume();
+    this.obstacles.forEach(obs => {
+      if (obs.sprite && obs.sprite.anims) {
+        obs.sprite.anims.resume();
+      }
+    });
+    
+    // Resume jumpscare animations
+    if (this.jumpScare) {
+      this.jumpScare.resumeAnimations();
+    }
+  }
+
   update(_t, delta) {
     if (this.parallax.length === 0) return;
+    if (this.isPaused) return; // Don't update game when paused
+    
     const base = (this.gameSpeed * delta) / 1000;
     const backgroundMove = base * this.backgroundSpeedMultiplier;
     const obstacleMove = base * this.obstacleSpeedMultiplier;
@@ -262,6 +344,7 @@ class GameScene extends Phaser.Scene {
     // Random spawn interval between 3 and 5 seconds (farther apart)
     return Phaser.Math.Between(3000, 5000);
   }
+
 }
 
 export default GameScene;

--- a/src/scenes/PauseScene.js
+++ b/src/scenes/PauseScene.js
@@ -1,0 +1,69 @@
+// filepath: c:\Users\Jakey\Documents\vs-code-projects\haunted-runner\src\scenes\PauseScene.js
+import Phaser from 'phaser';
+import ConsentModal from '../utils/ConsentModal';
+import MusicManager from '../utils/MusicManager';
+
+export default class PauseScene extends Phaser.Scene {
+  constructor() {
+    super('PauseScene');
+  }
+
+  create() {
+    const { width: W, height: H } = this.scale;
+
+    // Semi-transparent overlay covering the entire screen
+    this.add.rectangle(0, 0, W, H, 0x000000, 0.5)
+      .setOrigin(0, 0)
+      .setScrollFactor(0)
+      .setDepth(0)
+      .setInteractive(); // Block clicks from passing through
+
+    // Show the consent modal
+    new ConsentModal(this, (preferences) => {
+      this.handleModalClose(preferences);
+    });
+  }
+
+  handleModalClose(preferences) {
+    // Get the paused GameScene
+    const gameScene = this.scene.get('GameScene');
+    
+    // Update preferences in GameScene
+    if (gameScene) {
+      // Check if music preference changed
+      const currentMusicState = gameScene.registry.get('musicEnabled');
+      if (preferences.musicEnabled !== currentMusicState) {
+        // Toggle music in GameScene
+        MusicManager.toggleMusic(gameScene);
+        // Update the music button icon
+        if (gameScene.musicButton) {
+          gameScene.musicButton.setText(preferences.musicEnabled ? '🔊' : '🔇');
+        }
+      }
+      
+      // Check if jumpscare preference changed
+      const jumpscareChanged = preferences.jumpscareEnabled !== gameScene.jumpscareEnabled;
+      gameScene.jumpscareEnabled = preferences.jumpscareEnabled;
+      gameScene.musicEnabled = preferences.musicEnabled;
+      
+      // If jumpscares were disabled, stop auto triggers
+      if (jumpscareChanged && !preferences.jumpscareEnabled && gameScene.jumpScare) {
+        gameScene.jumpScare.stopAuto();
+      }
+      // If jumpscares were enabled, restart auto triggers
+      else if (jumpscareChanged && preferences.jumpscareEnabled && gameScene.jumpScare) {
+        gameScene.jumpScare.startAuto({ min: 12, max: 24 });
+      }
+      
+      gameScene.isPaused = false; // Resume gameplay
+      gameScene.resumeAnimations(); // Resume all animations
+    }
+
+    this.resumeGame();
+  }
+
+  resumeGame() {
+    // Just stop the pause scene, GameScene keeps running
+    this.scene.stop('PauseScene');
+  }
+}


### PR DESCRIPTION
- PauseScene overlays ConsentModal for settings
- P key toggles pause/unpause, Settings cog opens menu
- Manual pause flag prevents AudioContext errors
- Freeze all animations and disable input during pause
- Music and jumpscare toggles work in real-time
- Preferences saved to localStorage